### PR TITLE
Disable insurance confirmation button after tap

### DIFF
--- a/Sources/Fullscreen/MotorTransactionInsuranceConfirmationView/MotorTransactionInsuranceConfirmationView.swift
+++ b/Sources/Fullscreen/MotorTransactionInsuranceConfirmationView/MotorTransactionInsuranceConfirmationView.swift
@@ -150,6 +150,7 @@ public class MotorTransactionInsuranceConfirmationView: ShadowScrollView {
     // MARK: - Actions
 
     @objc private func handleConfirmationButtonTap() {
+        confirmationButton.isEnabled = false
         delegate?.motorTransactionInsuranceConfirmationViewDidTapButton(self)
     }
 }


### PR DESCRIPTION
# Why?

- Each tap on the button triggers a new request of purchasing insurance. The request takes a couple of seconds to process and causes some frustration to the user which ends up tapping it multiple times.

# What?

- Disable insurance confirmation button after tapping it once.

# Version Change

Minor change