### PR TITLE
Bump FinniversKit to 81.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ fastlane/report.xml
 
 # SPM
 .swiftpm
+.build

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/finn-no/FinniversKit.git",
         "state": {
           "branch": null,
-          "revision": "2e2e0dd44444cf578a2bc461067102f4a8f082d7",
-          "version": "73.1.0"
+          "revision": "0f509b10106663d375c43810adfffd43308edd54",
+          "version": "81.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(name: "FinniversKit", url: "https://github.com/finn-no/FinniversKit.git", from: "73.1.0"),
+        .package(name: "FinniversKit", url: "https://github.com/finn-no/FinniversKit.git", from: "81.0.0"),
     ],
     targets: [
     	.target(

--- a/Workspace/FinnUIDemo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Workspace/FinnUIDemo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/finn-no/FinniversKit.git",
         "state": {
           "branch": null,
-          "revision": "2e2e0dd44444cf578a2bc461067102f4a8f082d7",
-          "version": "73.1.0"
+          "revision": "0f509b10106663d375c43810adfffd43308edd54",
+          "version": "81.0.0"
         }
       },
       {


### PR DESCRIPTION
# Why?
In order to include this repo in SearchQuest I need it to depend on the same version of FinniversKit as SearchQuest.

# What?
- Bumped to 81.0.0

# Version Change
Minor

# UI Changes
None