### PR TITLE
Explore detail: iPad support

### DIFF
--- a/FinnUI.podspec
+++ b/FinnUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FinnUI'
-  s.version      = '23.3.0'
+  s.version      = '23.3.1'
   s.summary      = "FINN's iOS UI Features"
   s.author       = 'FINN.no'
   s.homepage     = 'https://schibsted.frontify.com/d/oCLrx0cypXJM/design-system'

--- a/Sources/Fullscreen/ExploreDetail/ExploreDetailView.swift
+++ b/Sources/Fullscreen/ExploreDetail/ExploreDetailView.swift
@@ -69,7 +69,11 @@ public final class ExploreDetailView: UIView {
             frame: bounds,
             collectionViewLayout: UICollectionViewCompositionalLayout { [weak self] sectionIndex, _ in
                 guard let self = self else { return nil }
-                return self.layoutBuilder.collectionLayoutSection(for: self.sections[sectionIndex], at: sectionIndex)
+                return self.layoutBuilder.collectionLayoutSection(
+                    for: self.sections[sectionIndex],
+                    at: sectionIndex,
+                    traitCollection: self.traitCollection
+                )
             }
         )
         collectionView.showsVerticalScrollIndicator = false

--- a/Sources/Fullscreen/ExploreDetail/Helpers/ExploreDetailLayoutBuilder.swift
+++ b/Sources/Fullscreen/ExploreDetail/Helpers/ExploreDetailLayoutBuilder.swift
@@ -10,15 +10,16 @@ struct ExploreDetailLayoutBuilder {
 
     func collectionLayoutSection(
         for section: ExploreDetailSection,
-        at sectionIndex: Int
+        at sectionIndex: Int,
+        traitCollection: UITraitCollection
     ) -> NSCollectionLayoutSection {
         let headerId = UICollectionView.elementKindSectionHeader
 
         switch section.items {
         case .collections(let collections):
-            let layoutSection: NSCollectionLayoutSection = collections.count > 5
-                ? .twoRowsGrid
-                : .carouselSection(itemSize: CGSize(width: 140, height: 96))
+            let layoutSection: NSCollectionLayoutSection = collections.count < 6 || traitCollection.horizontalSizeClass == .regular
+                ? .carouselSection(itemSize: CGSize(width: 140, height: 96))
+                : .twoRowsGrid
             if section.title != nil {
                 layoutSection.boundarySupplementaryItems = [.header(with: headerId, height: .absolute(49))]
             }
@@ -31,7 +32,7 @@ struct ExploreDetailLayoutBuilder {
             }
             return layoutSection
         case .ads(let ads):
-            let layoutSection = NSCollectionLayoutSection.staggered(with: ads)
+            let layoutSection = NSCollectionLayoutSection.staggered(with: ads, traitCollection: traitCollection)
 
             if sectionIndex == 0 {
                 layoutSection.contentInsets.top = .spacingL

--- a/Sources/Fullscreen/ExploreDetail/Helpers/NSCollectionLayoutSection+Staggered.swift
+++ b/Sources/Fullscreen/ExploreDetail/Helpers/NSCollectionLayoutSection+Staggered.swift
@@ -24,9 +24,9 @@ public protocol StaggeredLayoutItem {
 // MARK: - Staggered layout
 
 public extension NSCollectionLayoutSection {
-    static func staggered(with models: [StaggeredLayoutItem]) -> NSCollectionLayoutSection {
+    static func staggered(with models: [StaggeredLayoutItem], traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
+        let configuration = GridLayoutConfiguration(traitCollection: traitCollection)
         let contentWidth = UIScreen.main.bounds.size.width
-        let configuration = GridLayoutConfiguration(width: contentWidth)
         let columnItemWidth = configuration.itemWidth(for: contentWidth)
         var items = [NSCollectionLayoutGroupCustomItem]()
         let columnsRange = 0 ..< configuration.numberOfColumns
@@ -42,14 +42,14 @@ public extension NSCollectionLayoutSection {
                     itemWidth: columnItemWidth,
                     columnIndex: columnIndex
                 )
-                let yOffset = CGFloat(columns[columnIndex]) + configuration.topOffset
+                let yOffset = CGFloat(columns[columnIndex])
                 let itemHeight = self.itemHeight(model: model, itemWidth: columnItemWidth)
                 frame = CGRect(x: xOffset, y: yOffset, width: columnItemWidth, height: itemHeight)
                 columns[columnIndex] = Int(frame.maxY + configuration.columnSpacing)
             case .fullWidth:
                 let columnIndex = configuration.indexOfHighestValue(in: columns)
                 let xOffset = configuration.sidePadding
-                let yOffset = CGFloat(columns[columnIndex]) + configuration.topOffset
+                let yOffset = CGFloat(columns[columnIndex])
                 let itemWidth = contentWidth - configuration.sidePadding * 2
                 let itemHeight = self.itemHeight(model: model, itemWidth: itemWidth)
                 frame = CGRect(x: xOffset, y: yOffset, width: itemWidth, height: itemHeight)
@@ -91,37 +91,15 @@ public extension NSCollectionLayoutSection {
 
 // MARK: - Configuration
 
-private enum GridLayoutConfiguration {
-    case small
-    case medium
-    case large
-
-    static let mediumRange: Range<CGFloat> = (375.0 ..< 450.0)
-
-    init(width: CGFloat) {
-        switch width {
-        case let width where width > GridLayoutConfiguration.mediumRange.upperBound:
-            self = .large
-        case let width where width < GridLayoutConfiguration.mediumRange.lowerBound:
-            self = .small
-        default:
-            self = .medium
-        }
+private struct GridLayoutConfiguration {
+    init(traitCollection: UITraitCollection) {
+        numberOfColumns = traitCollection.horizontalSizeClass == .regular ? 3 : 2
     }
 
-    var topOffset: CGFloat {
-        switch self {
-        case .large:
-            return 10
-        default:
-            return 0
-        }
-    }
-
-    var sidePadding: CGFloat { 16 }
-    var lineSpacing: CGFloat { 16 }
-    var columnSpacing: CGFloat { 16 }
-    var numberOfColumns: Int { 2 }
+    let numberOfColumns: Int
+    let sidePadding: CGFloat = .spacingM
+    let lineSpacing: CGFloat = .spacingM
+    let columnSpacing: CGFloat = .spacingM
 
     func itemWidth(for collectionViewWidth: CGFloat) -> CGFloat {
         let columnPadding = columnSpacing * CGFloat(numberOfColumns - 1)


### PR DESCRIPTION
# Why?

There is room to show 3 column grid on iPad.

# What?

- Ads section: show 3 column grid on iPad
- Collections section: always show one row carousel on iPad

# Version Change

Patch change.

# UI Changes


| Before | After |
| --- | --- |
| <img width="869" alt="Screenshot 2021-06-25 at 12 24 24" src="https://user-images.githubusercontent.com/10529867/123411032-4ac02980-d5b0-11eb-881b-dd3f307ad67c.png"> | <img width="868" alt="Screenshot 2021-06-25 at 12 23 37" src="https://user-images.githubusercontent.com/10529867/123410936-2c5a2e00-d5b0-11eb-825b-f288f5f1ef3f.png"> |