### PR TITLE
Fix crash when using ExploreView

### DIFF
--- a/Sources/Extensions/Foundation/ArrayExtensions.swift
+++ b/Sources/Extensions/Foundation/ArrayExtensions.swift
@@ -1,0 +1,17 @@
+//
+//  Copyright © FINN.no AS. All rights reserved.
+//
+
+import Foundation
+
+extension Array where Array.Element: ExpressibleByNilLiteral {
+    subscript(safe index: Index) -> Element {
+        return indices.contains(index) ? self[index] : nil
+    }
+}
+
+extension Array {
+    subscript(safe index: Index) -> Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Sources/Fullscreen/Explore/ExploreView.swift
+++ b/Sources/Fullscreen/Explore/ExploreView.swift
@@ -45,8 +45,8 @@ public final class ExploreView: UIView {
         let collectionView = UICollectionView(
             frame: bounds,
             collectionViewLayout: UICollectionViewCompositionalLayout { [weak self] sectionIndex, _ in
-                guard let self = self else { return nil }
-                return self.layoutBuilder.collectionLayoutSection(for: self.sections[sectionIndex])
+                guard let self = self, let section = self.sections[safe: sectionIndex] else { return nil }
+                return self.layoutBuilder.collectionLayoutSection(for: section)
             }
         )
         collectionView.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
# Why?
Was able to produce a crash when leaving the view before everything had loaded.

# What?
- Make sure the sectionIndex is valid before using it (in the crash situation we got sectionIndex 0 but had no sections yet).
- Added ArrayExtensions so that is easy to do with the `array[safe: x]`.


# Version Change
Minor / patch
