### PR TITLE
Fix crash when using ExploreDetailView

### DIFF
--- a/Sources/Fullscreen/Explore/ExploreView.swift
+++ b/Sources/Fullscreen/Explore/ExploreView.swift
@@ -92,7 +92,7 @@ public final class ExploreView: UIView {
             })
 
         dataSource.supplementaryViewProvider = { [weak self] collectionView, kind, indexPath in
-            guard let section = self?.sections[indexPath.section], let title = section.title else { return nil }
+            guard let section = self?.sections[safe: indexPath.section], let title = section.title else { return nil }
             let view = collectionView.dequeue(
                 ExploreSectionHeaderView.self,
                 for: indexPath,

--- a/Sources/Fullscreen/ExploreDetail/ExploreDetailView.swift
+++ b/Sources/Fullscreen/ExploreDetail/ExploreDetailView.swift
@@ -70,7 +70,7 @@ public final class ExploreDetailView: UIView {
             collectionViewLayout: UICollectionViewCompositionalLayout { [weak self] sectionIndex, _ in
                 guard let self = self else { return nil }
                 return self.layoutBuilder.collectionLayoutSection(
-                    for: self.sections[sectionIndex],
+                    for: self.sections[safe: sectionIndex],
                     at: sectionIndex,
                     traitCollection: self.traitCollection
                 )
@@ -121,7 +121,7 @@ public final class ExploreDetailView: UIView {
             })
 
         dataSource.supplementaryViewProvider = { [weak self] collectionView, kind, indexPath in
-            guard let section = self?.sections[indexPath.section], let title = section.title else {
+            guard let section = self?.sections[safe: indexPath.section], let title = section.title else {
                 return nil
             }
 

--- a/Sources/Fullscreen/ExploreDetail/ExploreDetailView.swift
+++ b/Sources/Fullscreen/ExploreDetail/ExploreDetailView.swift
@@ -68,9 +68,9 @@ public final class ExploreDetailView: UIView {
         let collectionView = UICollectionView(
             frame: bounds,
             collectionViewLayout: UICollectionViewCompositionalLayout { [weak self] sectionIndex, _ in
-                guard let self = self else { return nil }
+                guard let self = self, let section = self.sections[safe: sectionIndex] else { return nil }
                 return self.layoutBuilder.collectionLayoutSection(
-                    for: self.sections[safe: sectionIndex],
+                    for: section,
                     at: sectionIndex,
                     traitCollection: self.traitCollection
                 )


### PR DESCRIPTION
# Why?
There is a way to make the ExploreDetailView crash that needs to be fixed. Same as was fixed for ExploreView in https://github.com/finn-no/finnui-ios/pull/24

# What?
Make sure the sectionIndex is valid before using it (in the crash situation we got sectionIndex 0 but had no sections yet).

# Version Change
Patch
