### PR TITLE
Set zoom level in map for promoted realestate cells

### DIFF
--- a/Demo/Sources/Recycling/PromotedCells/PromotedRealestateCellDemoView.swift
+++ b/Demo/Sources/Recycling/PromotedCells/PromotedRealestateCellDemoView.swift
@@ -106,7 +106,8 @@ private extension PromotedRealestateCellViewModel {
             realtorName: "FINN Eiendom",
             realtorImageUrl: "https://kommunikasjon.ntb.no/data/images/00171/daaffdf6-fb0e-4e74-9b6b-7f973dbfa6a3.png",
             highlightColor: UIColor(hex: "#0063FB"),
-            mapCoordinates: CLLocationCoordinate2D(latitude: 59.9137496948242, longitude: 10.7438659667969)
+            mapCoordinates: CLLocationCoordinate2D(latitude: 59.9137496948242, longitude: 10.7438659667969),
+            zoomLevel: 14
         )
     }
 
@@ -123,7 +124,8 @@ private extension PromotedRealestateCellViewModel {
             realtorName: nil,
             realtorImageUrl: "https://kommunikasjon.ntb.no/data/images/00171/daaffdf6-fb0e-4e74-9b6b-7f973dbfa6a3.png",
             highlightColor: UIColor(hex: "#0063FB"),
-            mapCoordinates: CLLocationCoordinate2D(latitude: 59.9137496948242, longitude: 10.7438659667969)
+            mapCoordinates: CLLocationCoordinate2D(latitude: 59.9137496948242, longitude: 10.7438659667969),
+            zoomLevel: nil
         )
     }
 }

--- a/Sources/Recycling/PromotedCells/PromotedRealestateCellView.swift
+++ b/Sources/Recycling/PromotedCells/PromotedRealestateCellView.swift
@@ -42,6 +42,7 @@ public class PromotedRealestateCellView: UIView {
         primaryImageUrl: viewModel.primaryImageUrl,
         secondaryImageUrl: viewModel.secondaryImageUrl,
         mapCoordinates: viewModel.mapCoordinates,
+        zoomLevel: viewModel.zoomLevel,
         remoteImageViewDataSource: remoteImageViewDataSource
     )
 

--- a/Sources/Recycling/PromotedCells/PromotedRealestateCellViewModel.swift
+++ b/Sources/Recycling/PromotedCells/PromotedRealestateCellViewModel.swift
@@ -14,6 +14,7 @@ public struct PromotedRealestateCellViewModel {
     public let realtorImageUrl: String?
     public let highlightColor: UIColor?
     public let mapCoordinates: CLLocationCoordinate2D?
+    public let zoomLevel: Int?
 
     public init(
         title: String?,
@@ -27,7 +28,8 @@ public struct PromotedRealestateCellViewModel {
         realtorName: String?,
         realtorImageUrl: String?,
         highlightColor: UIColor?,
-        mapCoordinates: CLLocationCoordinate2D?
+        mapCoordinates: CLLocationCoordinate2D?,
+        zoomLevel: Int?
     ) {
         self.title = title
         self.address = address
@@ -41,5 +43,6 @@ public struct PromotedRealestateCellViewModel {
         self.realtorImageUrl = realtorImageUrl
         self.highlightColor = highlightColor
         self.mapCoordinates = mapCoordinates
+        self.zoomLevel = zoomLevel
     }
 }

--- a/Sources/Recycling/PromotedCells/Subviews/ImageMapGridView.swift
+++ b/Sources/Recycling/PromotedCells/Subviews/ImageMapGridView.swift
@@ -164,6 +164,10 @@ private extension MKMapView {
         coordinates: CLLocationCoordinate2D,
         zoomLevel: Int
     ) {
+        guard zoomLevel >= 0, zoomLevel <= 20 else {
+            centerToLocation(coordinates: coordinates)
+            return
+        }
         let span = MKCoordinateSpan(latitudeDelta: 0, longitudeDelta: 360 / pow(2, Double(zoomLevel)) * Double(frame.size.width) / 256)
         setRegion(MKCoordinateRegion(center: coordinates, span: span), animated: false)
     }


### PR DESCRIPTION
# Why?

We get zoom level as part of the backend response for promoted realestate ads (in search results) now, so adding support for this in the view.

# What?

Add new function that centers to location with a specific zoom level. 
Got the calculation for zoom level from here https://stackoverflow.com/questions/4189621/setting-the-zoom-level-for-a-mkmapview , so not 100% sure how it works. But it looks correct.

I also validated the `zoomLevel` submitted is a reasonable value. If it's invalid or nil, we fall back on the old way of centering with a region radius.

# Version Change

Major.

# UI Changes

| Before | After - with a zoom level of 14 |
| --- | --- |
| ![before-highlight](https://user-images.githubusercontent.com/17450858/135631298-e1e3cc9a-4bad-49cd-beca-3b5b984888ac.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-10-01 at 15 44 51](https://user-images.githubusercontent.com/17450858/135631322-9f623a12-9c6c-4ba0-8656-16ccad22e7eb.png)|
