### PR TITLE
Update for iOS 15 compatibility (diffable datasource change)

### DIFF
--- a/Sources/Components/TagCloudGridView/TagCloudGridView.swift
+++ b/Sources/Components/TagCloudGridView/TagCloudGridView.swift
@@ -99,11 +99,17 @@ public final class TagCloudGridView: UIView, UICollectionViewDelegate {
         var snapshot = NSDiffableDataSourceSnapshot<Int, TagCloudCellViewModel>()
         snapshot.appendSections([0])
         snapshot.appendItems(items)
-        if #available(iOS 15.0, *) {
-            dataSource.applySnapshotUsingReloadData(snapshot)
-        } else {
+
+        // Support compiling on both Xcode 12 and Xcode 13 (and above)
+        #if swift(>=5.5)
+            if #available(iOS 15.0, *) {
+                dataSource.applySnapshotUsingReloadData(snapshot)
+            } else {
+                dataSource.apply(snapshot, animatingDifferences: false)
+            }
+        #else
             dataSource.apply(snapshot, animatingDifferences: false)
-        }
+        #endif
     }
 
     private func setup() {

--- a/Sources/Fullscreen/Explore/ExploreView.swift
+++ b/Sources/Fullscreen/Explore/ExploreView.swift
@@ -140,11 +140,16 @@ public final class ExploreView: UIView {
         }
 
         refreshControl.endRefreshing()
-        if #available(iOS 15.0, *) {
-            collectionViewDataSource.applySnapshotUsingReloadData(snapshot)
-        } else {
+        // Support compiling on both Xcode 12 and Xcode 13 (and above)
+        #if swift(>=5.5)
+            if #available(iOS 15.0, *) {
+                collectionViewDataSource.applySnapshotUsingReloadData(snapshot)
+            } else {
+                collectionViewDataSource.apply(snapshot, animatingDifferences: false)
+            }
+        #else
             collectionViewDataSource.apply(snapshot, animatingDifferences: false)
-        }
+        #endif
     }
 
     private func setup() {


### PR DESCRIPTION
# Why?
The diffable datasource behaves differently for the same method call in iOS 14 and 15.

# What?
Use new applySnapshotUsingReloadData instead of apply(snapshot, animatingDifferences: false) on iOS 15.

# Version Change
Patch (this should not change anything for per iOS 15 or when compiling on Xcode 12)