### PR TITLE
Remove checks if iOS 13 is available

### DIFF
--- a/Demo/SnapshotTests/SwiftUIViewTests.swift
+++ b/Demo/SnapshotTests/SwiftUIViewTests.swift
@@ -7,7 +7,6 @@ import XCTest
 import SwiftUI
 @testable import FinnUI
 
-@available(iOS 13.0, *)
 class SwiftUIViewTests: XCTestCase {
     private func snapshot(
         _ component: SwiftUIDemoViews,

--- a/Demo/Sources/AppDelegate.swift
+++ b/Demo/Sources/AppDelegate.swift
@@ -19,9 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             Config.userInterfaceStyleSupport = State.defaultUserInterfaceStyleSupport
         }
         window = UIWindow(frame: UIScreen.main.bounds)
-        if #available(iOS 13.0, *) {
-            window?.setWindowUserInterfaceStyle(userInterfaceStyle)
-        }
+        window?.setWindowUserInterfaceStyle(userInterfaceStyle)
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
 

--- a/Demo/Sources/Demo/DemoHelpers.swift
+++ b/Demo/Sources/Demo/DemoHelpers.swift
@@ -14,17 +14,7 @@ enum Sections: String, CaseIterable {
     case components
     case recycling
     case fullscreen
-    @available(iOS 13.0, *) case swiftui
-
-    static var allCases: [Sections] {
-        var cases: [Sections] = [.components, .recycling, .fullscreen]
-
-        if #available(iOS 13.0, *) {
-            cases.append(.swiftui)
-        }
-
-        return cases
-    }
+    case swiftui
 
     static var items: [Sections] {
         return allCases
@@ -39,10 +29,7 @@ enum Sections: String, CaseIterable {
         case .fullscreen:
             return FullscreenDemoViews.items.count
         case .swiftui:
-            if #available(iOS 13.0, *) {
-                return SwiftUIDemoViews.items.count
-            }
-            return 0
+            return SwiftUIDemoViews.items.count
         }
     }
 
@@ -63,11 +50,7 @@ enum Sections: String, CaseIterable {
         case .fullscreen:
             names = FullscreenDemoViews.items.map { $0.rawValue.capitalizingFirstLetter }
         case .swiftui:
-            if #available(iOS 13.0, *) {
-                names = SwiftUIDemoViews.items.map { $0.rawValue.capitalizingFirstLetter }
-            } else {
-                names = []
-            }
+            names = SwiftUIDemoViews.items.map { $0.rawValue.capitalizingFirstLetter }
         }
         return names
     }
@@ -83,11 +66,7 @@ enum Sections: String, CaseIterable {
         case .fullscreen:
             rawClassName = FullscreenDemoViews.items[indexPath.row].rawValue
         case .swiftui:
-            if #available(iOS 13.0, *) {
-                rawClassName = SwiftUIDemoViews.items[indexPath.row].rawValue
-            } else {
-                rawClassName = ""
-            }
+            rawClassName = SwiftUIDemoViews.items[indexPath.row].rawValue
         }
 
         return rawClassName.capitalizingFirstLetter
@@ -114,10 +93,8 @@ enum Sections: String, CaseIterable {
             let selectedView = FullscreenDemoViews.items[safe: indexPath.row]
             viewController = selectedView?.viewController
         case .swiftui:
-            if #available(iOS 13.0, *) {
-                let selectedView = SwiftUIDemoViews.items[safe: indexPath.row]
-                viewController = selectedView?.viewController
-            }
+            let selectedView = SwiftUIDemoViews.items[safe: indexPath.row]
+            viewController = selectedView?.viewController
         }
 
         let sectionType = Sections.for(indexPath)

--- a/Demo/Sources/Demo/DemoViews/SwiftUIDemoViews.swift
+++ b/Demo/Sources/Demo/DemoViews/SwiftUIDemoViews.swift
@@ -5,7 +5,6 @@
 import SwiftUI
 @testable import FinnUI
 
-@available(iOS 13.0, *)
 public enum SwiftUIDemoViews: String, DemoViews {
     case buttons
     case settings

--- a/Demo/Sources/Demo/DemoViewsTableViewController.swift
+++ b/Demo/Sources/Demo/DemoViewsTableViewController.swift
@@ -46,13 +46,11 @@ class DemoViewsTableViewController: UITableViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        if #available(iOS 13.0, *) {
-            #if swift(>=5.1)
+        #if swift(>=5.1)
             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                 userInterfaceStyleDidChange()
             }
-            #endif
-        }
+        #endif
     }
 
     @objc private func userInterfaceStyleDidChange() {
@@ -83,17 +81,6 @@ class DemoViewsTableViewController: UITableViewController {
             State.setCurrentUserInterfaceStyle(State.currentUserInterfaceStyle(for: traitCollection) == .light ? .dark : .light, in: view.window)
         }
         NotificationCenter.default.post(name: .didChangeUserInterfaceStyle, object: nil)
-
-        if #available(iOS 13.0, *) {
-        } else {
-            //Need to shutdown the app to make this work before dynamic colors were available
-            let alertController = UIAlertController(title: "Restart", message: "This requires a restart of the app", preferredStyle: .alert)
-            alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
-                exit(0)
-            }))
-            alertController.addAction(UIAlertAction(title: "Later", style: .cancel, handler: nil))
-            present(alertController, animated: true)
-        }
     }
 
     private func updateColors(animated: Bool) {

--- a/Demo/Sources/Demo/Helpers.swift
+++ b/Demo/Sources/Demo/Helpers.swift
@@ -20,10 +20,7 @@ struct State {
     static let currentUserInterfaceStyleKey = "currentUserInterfaceStyleKey"
 
     static let defaultUserInterfaceStyleSupport: UserInterfaceStyleSupport = {
-        if #available(iOS 13.0, *) {
-            return .dynamic
-        }
-        return .forceLight
+        return .dynamic
     }()
 
     static var lastSelectedIndexPath: IndexPath? {
@@ -96,9 +93,8 @@ struct State {
 
     /// Needs to be called from main thread on iOS 13
     static func setCurrentUserInterfaceStyle(_ userInterfaceStyle: UserInterfaceStyle?, in window: UIWindow?) {
-        if #available(iOS 13.0, *) {
-            window?.setWindowUserInterfaceStyle(userInterfaceStyle)
-        }
+        window?.setWindowUserInterfaceStyle(userInterfaceStyle)
+
         if let userInterfaceStyle = userInterfaceStyle {
             UserDefaults.standard.set(userInterfaceStyle.rawValue, forKey: currentUserInterfaceStyleKey)
             Config.userInterfaceStyleSupport = userInterfaceStyle == .dark ? .forceDark : .forceLight
@@ -110,17 +106,11 @@ struct State {
     }
 
     static func currentUserInterfaceStyle(for traitCollection: UITraitCollection) -> UserInterfaceStyle {
-        if #available(iOS 13.0, *) {
-            return traitCollection.userInterfaceStyle == .dark ? .dark : .light
-        } else {
-            let styleRawValue = UserDefaults.standard.integer(forKey: currentUserInterfaceStyleKey)
-            return UserInterfaceStyle(rawValue: styleRawValue) ?? .light
-        }
+        return traitCollection.userInterfaceStyle == .dark ? .dark : .light
     }
 }
 
 extension UIWindow {
-    @available(iOS 13.0, *)
     func setWindowUserInterfaceStyle(_ userInterfaceStyle: UserInterfaceStyle?) {
         #if swift(>=5.1)
         let uiUserInterfaceStyle: UIUserInterfaceStyle

--- a/Demo/Sources/Demo/NavigationController.swift
+++ b/Demo/Sources/Demo/NavigationController.swift
@@ -22,13 +22,11 @@ class NavigationController: UINavigationController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        if #available(iOS 13.0, *) {
-            #if swift(>=5.1)
-            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-                updateColors(animated: true)
-            }
-            #endif
+        #if swift(>=5.1)
+        if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            updateColors(animated: true)
         }
+        #endif
     }
 
     @objc private func userInterfaceStyleDidChange() {

--- a/Demo/Sources/Extensions/UIKit/UITraitCollection+Extensions.swift
+++ b/Demo/Sources/Extensions/UIKit/UITraitCollection+Extensions.swift
@@ -11,12 +11,8 @@ extension UIViewController {
 extension UITraitCollection {
     /// This method is intented to be used where `traitCollection` is not available, for example
     /// outside of views or view controllers. Given the idea is to identify if the horizontal size class is regular
-    /// similar at the old `UIDevice.isIPad()` then we fallback into that method for iOS 12 and under.
+    /// similar at the old `UIDevice.isIPad()`
     @objc static var isHorizontalSizeClassRegular: Bool {
-        if #available(iOS 13.0, *) {
-            return current.horizontalSizeClass == .regular
-        } else {
-            return UIDevice.isIPad()
-        }
+        return current.horizontalSizeClass == .regular
     }
 }

--- a/Demo/Sources/SwiftUI/BapAdView+Previews.swift
+++ b/Demo/Sources/SwiftUI/BapAdView+Previews.swift
@@ -5,7 +5,6 @@
 import SwiftUI
 @testable import FinnUI
 
-@available(iOS 13.0.0, *)
 // swiftlint:disable superfluous_disable_command type_name
 struct NewBapAdView_Previews: PreviewProvider {
     static var previews: some View {

--- a/Sources/AdView/BapAdView/BapAdView.swift
+++ b/Sources/AdView/BapAdView/BapAdView.swift
@@ -7,7 +7,6 @@ import FinniversKit
 import UIKit
 import Combine
 
-@available(iOS 13.0.0, *)
 public struct BapAdView<GalleryImageProvider: CollectionImageProvider, AuthorImageProvider: SingleImageProvider>: View {
     let viewModel: BapAdViewModel
     let actions: BapAdViewActions?
@@ -59,7 +58,6 @@ public struct BapAdView<GalleryImageProvider: CollectionImageProvider, AuthorIma
 }
 
 // MARK: - Subviews
-@available(iOS 13.0.0, *)
 extension BapAdView {
     private var imageGallery: some View {
         galleryImageProvider.map {
@@ -185,7 +183,6 @@ extension BapAdView {
 }
 
 // MARK: - Actions
-@available(iOS 13.0.0, *)
 extension BapAdView {
     func addToFavorites() {
         actions?.addToFavorites()
@@ -228,7 +225,6 @@ extension BapAdView {
     }
 }
 
-@available(iOS 13.0.0, *)
 //swiftlint:disable:next type_name superfluous_disable_command
 struct BapAdView_Previews: PreviewProvider {
     static var previews: some View {

--- a/Sources/AdView/Components/AuthorView/AuthorView.swift
+++ b/Sources/AdView/Components/AuthorView/AuthorView.swift
@@ -4,7 +4,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 struct AuthorView<ImageProvider: SingleImageProvider>: View {
     let author: AuthorViewModel
     @ObservedObject var imageProvider: ImageProvider
@@ -32,7 +31,6 @@ struct AuthorView<ImageProvider: SingleImageProvider>: View {
     }
 }
 
-@available(iOS 13.0, *)
 extension AuthorView {
     var profilePicture: some View {
         Image(uiImage: imageProvider.image)
@@ -58,7 +56,6 @@ extension AuthorView {
     }
 }
 
-@available(iOS 13.0, *)
 //swiftlint:disable:next type_name superfluous_disable_command
 struct AuthorView_Previews: PreviewProvider {
     static var previews: some View {

--- a/Sources/AdView/Components/AuthorView/SingleImageProvider.swift
+++ b/Sources/AdView/Components/AuthorView/SingleImageProvider.swift
@@ -6,7 +6,6 @@ import Combine
 import SwiftUI
 
 /// Protocol to fetch a single image given a URL
-@available(iOS 13.0, *)
 public protocol SingleImageProvider: ObservableObject {
     init(url: URL?)
     var image: UIImage { get }
@@ -14,7 +13,6 @@ public protocol SingleImageProvider: ObservableObject {
 }
 
 /// Simple implementation for the SingleImageProvider protocol for in-project previews
-@available(iOS 13.0, *)
 class SampleSingleImageProvider: ObservableObject, SingleImageProvider {
     let url: URL?
     @Published var image: UIImage = UIImage(named: .profile)

--- a/Sources/AdView/Components/DescriptionView/DescriptionView.swift
+++ b/Sources/AdView/Components/DescriptionView/DescriptionView.swift
@@ -5,7 +5,6 @@
 import SwiftUI
 import FinniversKit
 
-@available(iOS 13.0, *)
 struct DescriptionView: View {
     let viewModel: DescriptionViewModel
     @SwiftUI.State var isExpanded: Bool = false
@@ -47,7 +46,6 @@ struct DescriptionView: View {
     }
 }
 
-@available(iOS 13.0, *)
 //swiftlint:disable:next type_name superfluous_disable_command
 struct DescriptionView_Previews: PreviewProvider {
     static let ad = BapAdViewModel.sampleData

--- a/Sources/AdView/Components/ImageGalleryView/CollectionImageProvider.swift
+++ b/Sources/AdView/Components/ImageGalleryView/CollectionImageProvider.swift
@@ -5,7 +5,6 @@
 import SwiftUI
 
 /// Logic to fetch a collection of images
-@available(iOS 13.0, *)
 public protocol CollectionImageProvider: ObservableObject {
     init(urls: [URL])
     var images: [UIImage] { get }
@@ -14,7 +13,6 @@ public protocol CollectionImageProvider: ObservableObject {
 }
 
 /// Simple implementation for the CollectionImageProvider protocol for in-project previews
-@available(iOS 13.0, *)
 class SampleCollectionImageDownloader: ObservableObject, CollectionImageProvider {
     @Published var images: [UIImage] = []
     private var dataTasks: [URLSessionDataTask] = []

--- a/Sources/AdView/Components/ImageGalleryView/ImageGalleryView.swift
+++ b/Sources/AdView/Components/ImageGalleryView/ImageGalleryView.swift
@@ -4,7 +4,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 struct ImageGalleryView<ImageProvider: CollectionImageProvider>: View {
     @ObservedObject var imageProvider: ImageProvider
     @State var selectedImageIndex: Int = 0
@@ -21,7 +20,6 @@ struct ImageGalleryView<ImageProvider: CollectionImageProvider>: View {
     }
 }
 
-@available(iOS 13.0, *)
 extension ImageGalleryView {
     var totalImages: Int {
         imageProvider.imageCount

--- a/Sources/AdView/Components/PagerView.swift
+++ b/Sources/AdView/Components/PagerView.swift
@@ -6,7 +6,6 @@
 //
 import SwiftUI
 
-@available(iOS 13.0, *)
 struct PagerView<Content: View>: View {
     let pageCount: Int
     @Binding var currentIndex: Int

--- a/Sources/AdView/Components/PhoneNumberView/PhoneNumberView.swift
+++ b/Sources/AdView/Components/PhoneNumberView/PhoneNumberView.swift
@@ -5,7 +5,6 @@
 import SwiftUI
 import FinniversKit
 
-@available(iOS 13.0, *)
 struct PhoneNumberView: View {
     let viewModel: PhoneNumberViewModel
     @SwiftUI.State var showPhoneNumber: Bool = false
@@ -38,7 +37,6 @@ struct PhoneNumberView: View {
     }
 }
 
-@available(iOS 13.0.0, *)
 //swiftlint:disable:next type_name superfluous_disable_command
 struct PhoneNumberView_Previews: PreviewProvider {
     static var previews: some View {

--- a/Sources/AdView/Components/TryHeltHjemView/TryHeltHjemView.swift
+++ b/Sources/AdView/Components/TryHeltHjemView/TryHeltHjemView.swift
@@ -5,7 +5,6 @@
 import SwiftUI
 import FinniversKit
 
-@available(iOS 13.0, *)
 struct TryHeltHjemView: View {
     let viewModel: TryHeltHjemViewModel
     let onReadMore: (() -> Void)
@@ -49,7 +48,6 @@ struct TryHeltHjemView: View {
     }
 }
 
-@available(iOS 13.0, *)
 //swiftlint:disable:next type_name superfluous_disable_command
 struct TryHeltHjemView_Previews: PreviewProvider {
     static var previews: some View {

--- a/Sources/Base Components/ButtonStyle+Previews.swift
+++ b/Sources/Base Components/ButtonStyle+Previews.swift
@@ -5,7 +5,6 @@
 import SwiftUI
 import FinniversKit
 
-@available(iOS 13.0.0, *)
 struct ButtonStyleUsageDemoView: View {
     var body: some View {
         VStack(spacing: .spacingL) {
@@ -108,7 +107,6 @@ struct ButtonStyleUsageDemoView: View {
     }
 }
 
-@available(iOS 13.0.0, *)
 // swiftlint:disable:next superfluous_disable_command type_name
 struct ButtonStyleUsageDemoView_Previews: PreviewProvider {
     static var previews: some View {

--- a/Sources/Extensions/SwiftUI/ImageExtensions.swift
+++ b/Sources/Extensions/SwiftUI/ImageExtensions.swift
@@ -4,7 +4,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0, *)
 extension Image {
     init(_ assetName: ImageAsset) {
         self.init(assetName.rawValue)

--- a/Sources/Extensions/UIKit/UITraitCollectionExtensions.swift
+++ b/Sources/Extensions/UIKit/UITraitCollectionExtensions.swift
@@ -11,12 +11,8 @@ extension UIViewController {
 extension UITraitCollection {
     /// This method is intented to be used where `traitCollection` is not available, for example
     /// outside of views or view controllers. Given the idea is to identify if the horizontal size class is regular
-    /// similar at the old `UIDevice.isIPad()` then we fallback into that method for iOS 12 and under.
+    /// similar at the old `UIDevice.isIPad()`
     @objc static var isHorizontalSizeClassRegular: Bool {
-        if #available(iOS 13.0, *) {
-            return current.horizontalSizeClass == .regular
-        } else {
-            return UIDevice.isIPad()
-        }
+        return current.horizontalSizeClass == .regular
     }
 }

--- a/Sources/Fullscreen/Settings/Foundation/Modifiers/Appearance.swift
+++ b/Sources/Fullscreen/Settings/Foundation/Modifiers/Appearance.swift
@@ -4,14 +4,12 @@
 
 import SwiftUI
 
-@available(iOS 13.0.0, *)
 extension View {
     public func appearance<T: UIView>(customize: @escaping (T) -> Void) -> some View {
         Appearance(content: self, customize: customize)
     }
 }
 
-@available(iOS 13.0.0, *)
 extension List {
     public func listSeparatorStyleNone() -> some View {
         appearance { (view: UITableView) in
@@ -22,7 +20,6 @@ extension List {
 
 // MARK: - Private types
 
-@available(iOS 13.0.0, *)
 private struct Appearance<Content: View, UIViewType: UIView>: UIViewControllerRepresentable {
     private var content: Content
     private var customize: (UIViewType) -> Void

--- a/Sources/Fullscreen/Settings/Foundation/Modifiers/BottomDividerModifier.swift
+++ b/Sources/Fullscreen/Settings/Foundation/Modifiers/BottomDividerModifier.swift
@@ -4,7 +4,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0.0, *)
 public struct BottomDividerModifier: ViewModifier {
     let show: Bool
     let inset: EdgeInsets
@@ -22,7 +21,6 @@ public struct BottomDividerModifier: ViewModifier {
     }
 }
 
-@available(iOS 13.0.0, *)
 extension View {
     public func bottomDivider(
         _ show: Bool,

--- a/Sources/Fullscreen/Settings/Foundation/Views/BasicListCell.swift
+++ b/Sources/Fullscreen/Settings/Foundation/Views/BasicListCell.swift
@@ -5,7 +5,6 @@
 import SwiftUI
 import FinniversKit
 
-@available(iOS 13.0.0, *)
 public struct BasicListCell: View {
     var action: (() -> Void)?
     private let model: BasicTableViewCellViewModel
@@ -87,7 +86,6 @@ public struct BasicListCell: View {
     }
 }
 
-@available(iOS 13.0, *)
 private struct BasicButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
@@ -104,7 +102,6 @@ private struct BasicButtonStyle: ButtonStyle {
 
 // MARK: - Previews
 
-@available(iOS 13.0, *)
 // swiftlint:disable:next superfluous_disable_command type_name
 struct BasicListCell_Previews: PreviewProvider {
     private static let viewModels = [

--- a/Sources/Fullscreen/Settings/Foundation/Views/BasicListCellWrapper.swift
+++ b/Sources/Fullscreen/Settings/Foundation/Views/BasicListCellWrapper.swift
@@ -5,7 +5,6 @@
 import SwiftUI
 import FinniversKit
 
-@available(iOS 13.0.0, *)
 struct BasicListCellWrapper: UIViewControllerRepresentable {
     let cell: BasicListCell
     let onSelect: (UIView?) -> Void

--- a/Sources/Fullscreen/Settings/SettingsView.swift
+++ b/Sources/Fullscreen/Settings/SettingsView.swift
@@ -7,7 +7,6 @@ import FinniversKit
 
 // MARK: - View Model
 
-@available(iOS 13.0, *)
 public protocol SettingsViewModel: ObservableObject {
     var sections: [SettingsSection] { get }
     var versionText: String { get }
@@ -15,7 +14,6 @@ public protocol SettingsViewModel: ObservableObject {
 
 // MARK: - View
 
-@available(iOS 13.0.0, *)
 public struct SettingsView<ViewModel: SettingsViewModel>: View {
     @ObservedObject private var viewModel: ViewModel
     private var sections: [SettingsSection] { viewModel.sections }
@@ -85,7 +83,6 @@ public struct SettingsView<ViewModel: SettingsViewModel>: View {
 
 // MARK: - Cells
 
-@available(iOS 13.0.0, *)
 private struct Header: View {
     let text: String
 
@@ -106,7 +103,6 @@ private struct Header: View {
     }
 }
 
-@available(iOS 13.0.0, *)
 private struct Footer: View {
     let text: String
 
@@ -127,7 +123,6 @@ private struct Footer: View {
     }
 }
 
-@available(iOS 13.0.0, *)
 private struct ToggleCell: View {
     let model: SettingsViewToggleCellModel
     let onToggle: (Bool) -> Void
@@ -159,7 +154,6 @@ private struct ToggleCell: View {
     }
 }
 
-@available(iOS 13.0.0, *)
 private extension BasicListCell {
     init(model: SettingsViewConsentCellModel) {
         self.init(model: model, detailText: { _ in
@@ -170,7 +164,6 @@ private extension BasicListCell {
     }
 }
 
-@available(iOS 13.0.0, *)
 private struct VersionView: View {
     let text: String
 
@@ -193,7 +186,6 @@ private struct VersionView: View {
 
 // MARK: - Previews
 
-@available(iOS 13.0.0, *)
 // swiftlint:disable:next superfluous_disable_command type_name
 struct SettingsView_Previews: PreviewProvider {
     private static let viewModel = PreviewViewModel()
@@ -208,7 +200,6 @@ struct SettingsView_Previews: PreviewProvider {
     }
 }
 
-@available(iOS 13.0.0, *)
 private final class PreviewViewModel: SettingsViewModel {
     let versionText = "FinnUI Demo"
 


### PR DESCRIPTION
# Why?
Pre iOS 13 is no longer supported.

# What?
Remove a lot of checks if iOS 13 is available, we do not need that anymore.

# Version Change
Framework is already marked as min iOS 13 so this is a cosmetic change that has no effect at all on the produced binary.