### PR TITLE
Explore crash fix: Make all snapshot sections and items unique

### DIFF
--- a/Sources/Components/TagCloudGridView/Cell/TagCloudCellViewModel.swift
+++ b/Sources/Components/TagCloudGridView/Cell/TagCloudCellViewModel.swift
@@ -13,7 +13,7 @@ public protocol TagCloudLayoutDataProvider {
 
 // MARK: - View Model
 
-public struct TagCloudCellViewModel: Hashable, TagCloudLayoutDataProvider {
+public class TagCloudCellViewModel: UniqueHashableItem, TagCloudLayoutDataProvider {
     public let title: String
     public let iconUrl: String?
     public let backgroundColor: UIColor

--- a/Sources/Fullscreen/Explore/ViewModels/ExploreCollectionViewModel.swift
+++ b/Sources/Fullscreen/Explore/ViewModels/ExploreCollectionViewModel.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public struct ExploreCollectionViewModel: Hashable, TagCloudLayoutDataProvider {
+public class ExploreCollectionViewModel: UniqueHashableItem, TagCloudLayoutDataProvider {
     public let title: String
     public let imageUrl: String?
     public let iconUrl: String?

--- a/Sources/Fullscreen/Explore/ViewModels/ExploreSectionViewModel.swift
+++ b/Sources/Fullscreen/Explore/ViewModels/ExploreSectionViewModel.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public struct ExploreSectionViewModel: Hashable {
+public class ExploreSectionViewModel: UniqueHashableItem {
     public enum Layout {
         case hero
         case tagCloud

--- a/Sources/Fullscreen/ExploreDetail/ViewModels/ExploreAdCellViewModel.swift
+++ b/Sources/Fullscreen/ExploreDetail/ViewModels/ExploreAdCellViewModel.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-public struct ExploreAdCellViewModel: Hashable {
+public class ExploreAdCellViewModel: UniqueHashableItem {
     public let imageUrl: String?
     public let title: String?
     public let location: String?

--- a/Sources/Fullscreen/ExploreDetail/ViewModels/ExploreDetailViewModel.swift
+++ b/Sources/Fullscreen/ExploreDetail/ViewModels/ExploreDetailViewModel.swift
@@ -27,7 +27,7 @@ public struct ExploreDetailViewModel: Hashable {
 
 // MARK: - Section
 
-public struct ExploreDetailSection: Hashable {
+public class ExploreDetailSection: UniqueHashableItem {
     public enum Items: Hashable {
         case selectedCategories([ExploreCollectionViewModel])
         case collections([ExploreCollectionViewModel])

--- a/Sources/Helpers/UniqueHashableItem.swift
+++ b/Sources/Helpers/UniqueHashableItem.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public class UniqueHashableItem: Hashable {
+    private let identifier = UUID()
+
+    public static func == (lhs: UniqueHashableItem, rhs: UniqueHashableItem) -> Bool {
+        lhs.identifier == rhs.identifier
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        return hasher.combine(identifier)
+    }
+}


### PR DESCRIPTION
# Why?

After switching to a new backend, we got crash reports about non-unique section identifiers in explore snapshots:
`Fatal: supplied section identifiers are not unique. Duplicate identifiers: {( FinnUI.ExploreSectionViewModel ...`
We shouldn't crash when this happens. Therefore we won't rely on unique sections or items from the backend anymore.

# What?

Make `UniqueHashableItem`, an implementation of `Hashable` that should always be unique using `UUID`.
Use it for all sections and items in explore snapshots.

# Version Change

Patch.

# UI Changes

Might affect animations a bit.