### PR TITLE
Highlight listing: Add ribbon - to be used for sold units

### DIFF
--- a/Sources/Recycling/PromotedCells/PromotedRealestateCellView.swift
+++ b/Sources/Recycling/PromotedCells/PromotedRealestateCellView.swift
@@ -135,6 +135,17 @@ public class PromotedRealestateCellView: UIView {
             viewingInfoView.isHidden = true
         }
 
+        if let ribbonText = viewModel.ribbonText {
+            let ribbonView = RibbonView(viewModel: RibbonViewModel(style: .warning, title: ribbonText))
+            ribbonView.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(ribbonView)
+
+            NSLayoutConstraint.activate([
+                ribbonView.topAnchor.constraint(equalTo: topAnchor, constant: .spacingS),
+                ribbonView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: .spacingS)
+            ])
+        }
+
         configure(isFavorited: isFavorited)
     }
 

--- a/Sources/Recycling/PromotedCells/PromotedRealestateCellViewModel.swift
+++ b/Sources/Recycling/PromotedCells/PromotedRealestateCellViewModel.swift
@@ -17,6 +17,7 @@ public struct PromotedRealestateCellViewModel {
     public let highlightColor: UIColor?
     public let mapCoordinates: CLLocationCoordinate2D?
     public let zoomLevel: Int?
+    public let ribbonText: String?
 
     public init(
         title: String?,
@@ -33,7 +34,8 @@ public struct PromotedRealestateCellViewModel {
         realtorImageUrl: String?,
         highlightColor: UIColor?,
         mapCoordinates: CLLocationCoordinate2D?,
-        zoomLevel: Int?
+        zoomLevel: Int?,
+        ribbonText: String? = nil
     ) {
         self.title = title
         self.address = address
@@ -50,5 +52,6 @@ public struct PromotedRealestateCellViewModel {
         self.highlightColor = highlightColor
         self.mapCoordinates = mapCoordinates
         self.zoomLevel = zoomLevel
+        self.ribbonText = ribbonText
     }
 }

--- a/Workspace/FinnUIDemo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Workspace/FinnUIDemo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-snapshot-testing.git",
         "state": {
           "branch": null,
-          "revision": "c466812aa2e22898f27557e2e780d3aad7a27203",
-          "version": "1.8.2"
+          "revision": "f8a9c997c3c1dab4e216a8ec9014e23144cbab37",
+          "version": "1.9.0"
         }
       }
     ]


### PR DESCRIPTION
# Why?

We need a sold ribbon on real estate highlight listing cells.

# What?

Add optional `ribbonText` to view model.
If it's present, insert a `RibbonView` with that text.

# Version Change
Just a patch.

# UI Changes

See "Solgt" ribbon, otherwise no changes.

![Skjermbilde 2022-02-01 kl  17 14 47](https://user-images.githubusercontent.com/17450858/152007053-83be6596-ca46-403c-a673-f180e151c996.png)



