### PR TITLE
Fix: AgentProfileView compressed labels

### DIFF
--- a/Sources/Components/RealestateSoldState/Subviews/AgentProfileView.swift
+++ b/Sources/Components/RealestateSoldState/Subviews/AgentProfileView.swift
@@ -116,6 +116,7 @@ private extension Label {
     static func create(style: Label.Style) -> Label {
         let label = Label(style: style, withAutoLayout: true)
         label.numberOfLines = 0
+        label.setContentCompressionResistancePriority(.required, for: .vertical)
         return label
     }
 }


### PR DESCRIPTION
# Why?
I noticed the name and title labels in `AgentProfileView` were being compressed. Not sure when this happened, but I suspect #61.

# What?
- Set `contentCompressionResistancePriority` to `.required`.

# Version Change
Minor.

# UI Changes
| Before | After |
| --- | --- |
| <img width="551" alt="Screenshot 2022-02-21 at 10 29 11" src="https://user-images.githubusercontent.com/1901556/154927849-a07e71bc-20d4-4773-8206-4b2a05d90c7f.png"> | <img width="551" alt="Screenshot 2022-02-21 at 10 31 33" src="https://user-images.githubusercontent.com/1901556/154927876-34b214d2-d8fe-45af-93f6-550e55b95ebd.png"> |