### PR TITLE
Fix: Change contentMode for image in AgentProfileView

### DIFF
--- a/Sources/Components/RealestateSoldState/Subviews/AgentProfileView.swift
+++ b/Sources/Components/RealestateSoldState/Subviews/AgentProfileView.swift
@@ -30,7 +30,7 @@ class AgentProfileView: UIView {
 
     private lazy var remoteImageView: RemoteImageView = {
         let view = RemoteImageView(withAutoLayout: true)
-        view.contentMode = .scaleAspectFit
+        view.contentMode = .scaleAspectFill
         view.clipsToBounds = true
         view.setContentHuggingPriority(.defaultLow, for: .horizontal)
         view.setContentHuggingPriority(.defaultLow, for: .vertical)


### PR DESCRIPTION
# Why?
We've been using the incorrect `contentMode` for the image used to hold the realtor's image in `AgentProfileView`.

# What?
- Use `.scaleAspectFill` instead of `.scaleAspectFit`, so the image fills the `UIImageView`.

# Version Change
Patch.