### PR TITLE
Fix fiksferdig priceview

### DIFF
--- a/Demo/Sources/Components/Fiks Ferdig/FiksFerdigPriceView/FiksFerdigPriceDemoView.swift
+++ b/Demo/Sources/Components/Fiks Ferdig/FiksFerdigPriceView/FiksFerdigPriceDemoView.swift
@@ -91,11 +91,24 @@ struct FiksFerdigPriceViewModelBuilder {
         let logoAttachment = NSTextAttachment(image: paymentLogo)
         paymentAttributedText.append(NSAttributedString(attachment: logoAttachment))
 
+        let attributedText = shippingText.attributedHTMLString(
+            font: .bodyStrong,
+            style: ["tjt-price-highlight": UIColor.cherry.hexString],
+            textColor: .textPrimary.resolvedColor(with: .init(userInterfaceStyle: .light))
+        )
+
+        let darkModeAttributedText = shippingText.attributedHTMLString(
+            font: .bodyStrong,
+            style: ["tjt-price-highlight": UIColor.yellow.hexString],
+            textColor: .textPrimary.resolvedColor(with: .init(userInterfaceStyle: .dark))
+        )
+
         return FiksFerdigPriceViewModel(
             tradeType: tradeType,
             priceText: priceText,
             shipping: .init(
-                text: shippingText,
+                text: attributedText,
+                darkModeText: darkModeAttributedText,
                 accessibilityText: shippingAccessibilityText
             ),
             payment: .init(

--- a/Sources/Components/Fiks Ferdig/FiksFerdigPriceView/FiksFerdigPriceView.swift
+++ b/Sources/Components/Fiks Ferdig/FiksFerdigPriceView/FiksFerdigPriceView.swift
@@ -72,6 +72,7 @@ public final class FiksFerdigPriceView: UIView {
         tradeTypeLabel.text = viewModel.tradeType
         priceLabel.text = viewModel.priceString
         updateShippingLabel()
+
         if case .noPrice = viewModel.priceText {
             priceLabel.font = .title2Strong
         } else {
@@ -83,20 +84,11 @@ public final class FiksFerdigPriceView: UIView {
     }
 
     private func updateShippingLabel() {
-        // This has to be done only when the app is not in the background.
-        // https://stackoverflow.com/questions/46881393/ios-crash-report-unexpected-start-state-exception
-        guard
-            UIApplication.shared.applicationState != .background
-        else {
-            return
+        if traitCollection.userInterfaceStyle == .dark {
+            shippingLabel.attributedText = viewModel.shipping.darkModeText
+        } else {
+            shippingLabel.attributedText = viewModel.shipping.text
         }
-
-        shippingLabel.textColor = .textPrimary
-        let style = ["tjt-price-highlight": UIColor.discountedPriceLabel.hexString]
-        shippingLabel.setText(
-            fromHTMLString: viewModel.shipping.text,
-            style: style
-        )
     }
 
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/Sources/Components/Fiks Ferdig/FiksFerdigPriceView/FiksFerdigPriceViewModel.swift
+++ b/Sources/Components/Fiks Ferdig/FiksFerdigPriceView/FiksFerdigPriceViewModel.swift
@@ -27,7 +27,7 @@ public struct FiksFerdigPriceViewModel {
     }
 
     var shippingAccessibilityLabel: String {
-        return shipping.accessibilityText ?? shipping.text
+        return shipping.accessibilityText ?? shipping.text.string
     }
 }
 
@@ -38,14 +38,17 @@ extension FiksFerdigPriceViewModel {
     }
 
     public struct Shipping {
-        public let text: String
+        public let text: NSAttributedString
+        public let darkModeText: NSAttributedString
         public let accessibilityText: String?
 
         public init(
-            text: String,
+            text: NSAttributedString,
+            darkModeText: NSAttributedString,
             accessibilityText: String?
         ) {
             self.text = text
+            self.darkModeText = darkModeText
             self.accessibilityText = accessibilityText
         }
     }

--- a/Sources/Extensions/Foundation/String+Exts.swift
+++ b/Sources/Extensions/Foundation/String+Exts.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+public extension String {
+    func attributedHTMLString(font: UIFont, style: [String: String] = [:], textColor: UIColor) -> NSAttributedString {
+        var styledText = self
+        for (styleIdentifier, styleItem) in style {
+            styledText = styledText.replacingOccurrences(of: styleIdentifier, with: styleItem)
+        }
+        let htmlTemplate = "<span style=\"font-family: \(font.fontName); font-size: \(font.pointSize); color: \(textColor.hexString)\">\(styledText)</span>"
+
+        guard
+            let data = htmlTemplate.data(using: .utf8),
+            let attrStr = try? NSAttributedString(
+                data: data,
+                options: [.documentType: NSAttributedString.DocumentType.html],
+                documentAttributes: nil
+            )
+        else {
+            return NSAttributedString(string: self)
+        }
+
+        return attrStr
+    }
+}


### PR DESCRIPTION
# Why?

Updating `Label`'s `attributedText` resulted some weird layout issues in the FINN app when we used `FiksFerdigPriceView`.

# What?

The attributed string creation was moved to the view model.

# Version Change

Minor: The view model was extended by a property.
