### PR TITLE
Update fiks ferdig price view.

### DIFF
--- a/Sources/Components/Fiks Ferdig/FiksFerdigPriceView/FiksFerdigPriceView.swift
+++ b/Sources/Components/Fiks Ferdig/FiksFerdigPriceView/FiksFerdigPriceView.swift
@@ -73,11 +73,23 @@ public final class FiksFerdigPriceView: UIView {
         priceLabel.text = viewModel.priceString
         updateShippingLabel()
 
-        if case .noPrice = viewModel.priceText {
-            priceLabel.font = .title2Strong
-        } else {
-            priceLabel.font = .title1
+        var hasPrice: Bool {
+            if case .setPrice = viewModel.priceText {
+                return true
+            } else {
+                return false
+            }
         }
+
+        if hasPrice {
+            priceLabel.font = .title1
+        } else {
+            priceLabel.font = .title2Strong
+        }
+
+        tradeTypeLabel.isHidden = !hasPrice
+        shippingLabel.isHidden = !hasPrice
+
         paymentLabel.attributedText = viewModel.payment.text
         priceLabel.accessibilityLabel = viewModel.shippingAccessibilityLabel
         paymentLabel.accessibilityLabel = viewModel.payment.accessibilityText


### PR DESCRIPTION
# Why?

The fiks ferdig price view has to be changed according to UI and API specifications.

# What?

We don't have to display the shipping information when the price is not sepcified.

# Version Change

Minor: Only the look is changing.

# UI Changes

| Before | After |
| --- | --- |
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-08 at 13 16 54](https://user-images.githubusercontent.com/5146034/200561593-aea1879c-d82e-46f7-8d55-7649d26b249b.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-08 at 13 16 28](https://user-images.githubusercontent.com/5146034/200561653-c9924d9f-98bd-45b1-8a55-7e847d61325d.png) |
