### PR TITLE
set 1 column for when accessibility text size is enabled. 2 for ipad

### DIFF
--- a/Sources/Fullscreen/ExploreDetail/Helpers/NSCollectionLayoutSection+Staggered.swift
+++ b/Sources/Fullscreen/ExploreDetail/Helpers/NSCollectionLayoutSection+Staggered.swift
@@ -93,9 +93,14 @@ public extension NSCollectionLayoutSection {
 
 private struct GridLayoutConfiguration {
     init(traitCollection: UITraitCollection) {
-        numberOfColumns = traitCollection.horizontalSizeClass == .regular ? 3 : 2
+        if (traitCollection.preferredContentSizeCategory.isAccessibilityCategory){
+            numberOfColumns = traitCollection.horizontalSizeClass == .regular ? 2 : 1
+        }
+        else {
+            numberOfColumns = traitCollection.horizontalSizeClass == .regular ? 3 : 2
+        }
     }
-
+    
     let numberOfColumns: Int
     let sidePadding: CGFloat = .spacingM
     let lineSpacing: CGFloat = .spacingM


### PR DESCRIPTION
# Why?

Accessibility changes so low vision users will have an easier time.

# What?

Single column for collections scrolling. Double column for iPad, scaled down from the 3 default columns

# Version Change

minor

# UI Changes

this video shows old and new layouts. (Includes changes to FinniversKit as well.)

https://user-images.githubusercontent.com/17337441/212094921-de66406a-fee4-4e92-b167-70d151b8ef90.mov


