### PR TITLE
Explore recommendations: Fix aspect ratio for correct image heights

### DIFF
--- a/Sources/Fullscreen/Explore/Helpers/ExploreLayoutBuilder.swift
+++ b/Sources/Fullscreen/Explore/Helpers/ExploreLayoutBuilder.swift
@@ -144,7 +144,7 @@ extension ExploreRecommendationAdViewModel: StaggeredLayoutItem {
 
     public func staggeredLayoutItemHeight(forWidth width: CGFloat) -> StaggeredLayoutItemHeight {
         return .dynamic(
-            aspectRatio: imageSize.height/imageSize.width,
+            aspectRatio: imageSize.width / imageSize.height,
             extraHeight: StandardAdRecommendationCell.extraHeight()
         )
     }


### PR DESCRIPTION
# Why?

Noticed the image heights were a bit off in Explore recommendations. The aspect ratio is the opposite of what it should be.

# What?

Change so aspect ratio is calculated by width/height, instead of height/width.

# Version Change

Patch.

# UI Changes

| Before | After |
| --- | --- |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-01-20 at 09 05 16](https://user-images.githubusercontent.com/17450858/213647677-ed46297a-10b6-484a-bfd9-87ea6abdc468.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-01-20 at 09 04 45](https://user-images.githubusercontent.com/17450858/213647657-eb245788-708e-4525-bc81-0e0e8626457d.png) |
