### PR TITLE
Add badge to explore recommendations view model

### DIFF
--- a/Sources/Fullscreen/Explore/ViewModels/ExploreRecommendationAdViewModel.swift
+++ b/Sources/Fullscreen/Explore/ViewModels/ExploreRecommendationAdViewModel.swift
@@ -31,7 +31,8 @@ final public class ExploreRecommendationAdViewModel: StandardAdRecommendationVie
         isFavorite: Bool,
         scaleImageToFillView: Bool,
         sponsoredAdData: SponsoredAdData? = nil,
-        favoriteButtonAccessibilityLabel: String, id: String,
+        favoriteButtonAccessibilityLabel: String,
+        id: String,
         badgeViewModel: BadgeViewModel? = nil
     ) {
         self.imagePath = imagePath

--- a/Sources/Fullscreen/Explore/ViewModels/ExploreRecommendationAdViewModel.swift
+++ b/Sources/Fullscreen/Explore/ViewModels/ExploreRecommendationAdViewModel.swift
@@ -13,6 +13,7 @@ final public class ExploreRecommendationAdViewModel: StandardAdRecommendationVie
     public var scaleImageToFillView: Bool
     public var sponsoredAdData: FinniversKit.SponsoredAdData?
     public var favoriteButtonAccessibilityLabel: String
+    public let badgeViewModel: BadgeViewModel?
 
     public var hideImageOverlay: Bool {
         guard let imageText else { return true }
@@ -30,7 +31,8 @@ final public class ExploreRecommendationAdViewModel: StandardAdRecommendationVie
         isFavorite: Bool,
         scaleImageToFillView: Bool,
         sponsoredAdData: SponsoredAdData? = nil,
-        favoriteButtonAccessibilityLabel: String, id: String
+        favoriteButtonAccessibilityLabel: String, id: String,
+        badgeViewModel: BadgeViewModel? = nil
     ) {
         self.imagePath = imagePath
         self.imageSize = imageSize
@@ -44,6 +46,7 @@ final public class ExploreRecommendationAdViewModel: StandardAdRecommendationVie
         self.sponsoredAdData = sponsoredAdData
         self.favoriteButtonAccessibilityLabel = favoriteButtonAccessibilityLabel
         self.id = id
+        self.badgeViewModel = badgeViewModel
     }
 
     public func hash(into hasher: inout Hasher) {


### PR DESCRIPTION
# Why?

This is to help us support "Fiks ferdig" badges on recommendations in explore.

# What?

Feed in `BadgeViewModel` (optional) to `ExploreRecommendationAdViewModel`

# Version Change

Patch, since default is nil.

# UI Changes

This is how it will look once used. 
<img src="https://user-images.githubusercontent.com/17450858/213704973-0ddf4630-79a5-4b2a-b442-633164cd3203.png" width=400 />
