### PR TITLE
Fix: Set borderColor in layoutSubviews

### DIFF
--- a/Sources/Components/Fiks Ferdig/FiksFerdigContactSellerView/FiksFerdigContactSellerView.swift
+++ b/Sources/Components/Fiks Ferdig/FiksFerdigContactSellerView/FiksFerdigContactSellerView.swift
@@ -2,6 +2,9 @@ import FinniversKit
 import Combine
 
 public final class FiksFerdigContactSellerView: UIView {
+
+    // MARK: - Private properties
+
     private let viewModel: FiksFerdigContactSellerViewModel
     private var cancellable: AnyCancellable?
 
@@ -49,6 +52,8 @@ public final class FiksFerdigContactSellerView: UIView {
         return button
     }()
 
+    // MARK: - Init
+
     public init(viewModel: FiksFerdigContactSellerViewModel, withAutoLayout: Bool) {
         self.viewModel = viewModel
         super.init(frame: .zero)
@@ -60,6 +65,8 @@ public final class FiksFerdigContactSellerView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    // MARK: - Setup
 
     private func setup() {
         layer.borderWidth = 1
@@ -80,11 +87,15 @@ public final class FiksFerdigContactSellerView: UIView {
             })
     }
 
+    // MARK: - Overrides
 
     public override func layoutSubviews() {
         super.layoutSubviews()
         layer.borderColor = UIColor.borderDefault.cgColor
     }
+
+    // MARK: - Private methods
+
     private func decorate() {
         messageLabel.text = viewModel.message
         contactSellerButton.setTitle(viewModel.buttonTitle, for: .normal)

--- a/Sources/Components/Fiks Ferdig/FiksFerdigContactSellerView/FiksFerdigContactSellerView.swift
+++ b/Sources/Components/Fiks Ferdig/FiksFerdigContactSellerView/FiksFerdigContactSellerView.swift
@@ -63,7 +63,6 @@ public final class FiksFerdigContactSellerView: UIView {
 
     private func setup() {
         layer.borderWidth = 1
-        layer.borderColor = UIColor.borderDefault.cgColor
         layer.cornerRadius = 3
 
         addSubview(containerView)
@@ -81,6 +80,11 @@ public final class FiksFerdigContactSellerView: UIView {
             })
     }
 
+
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        layer.borderColor = UIColor.borderDefault.cgColor
+    }
     private func decorate() {
         messageLabel.text = viewModel.message
         contactSellerButton.setTitle(viewModel.buttonTitle, for: .normal)


### PR DESCRIPTION
# Why?

The border color in `FiksFerdigContactSellerView` were set in `setup()`, which doesn't get updated when/if changing to dark mode.

# What?
- Set `borderColor` in `layoutSubviews()`

# Version Change
Patch.

# UI Changes
_None._