### PR TITLE
not animating in differences

### DIFF
--- a/Sources/Fullscreen/Explore/ExploreView.swift
+++ b/Sources/Fullscreen/Explore/ExploreView.swift
@@ -212,7 +212,7 @@ public final class ExploreView: UIView {
 
         snapshot.appendItems(items)
 
-        collectionViewDataSource.apply(snapshot, animatingDifferences: true)
+        collectionViewDataSource.apply(snapshot, animatingDifferences: false)
     }
 
     // MARK: - Favorite button handling


### PR DESCRIPTION
# Why?

Turns out all phones and iPads on iOS 14 were crashing when loading more recommendations.

# What?

The animation of the differences was making them crash, and should have been turned off for everyone anyways because it doesn't look good. So turned animation off.

# Version Change

Patch

