### PR TITLE
Fixed recommendation section title bug

### DIFF
--- a/Sources/Fullscreen/Explore/ExploreView.swift
+++ b/Sources/Fullscreen/Explore/ExploreView.swift
@@ -140,8 +140,7 @@ public final class ExploreView: UIView {
                 guard let title = viewModel.title else { return nil }
                 view.configure(withText: title)
             case .recommendations:
-                guard let viewModel = self?.recommendationsSection[safe: indexPath.item] else { return nil }
-                let title = viewModel.title
+                guard let title = self?.recommendationsSectionTitle else { return nil }
                 view.configure(withText: title)
             }
             return view


### PR DESCRIPTION
# Why?
When making changes to the structure in section and how we configure ExploreView with recommendations we accidentally set the title of the recommendations section to the title of the first item in the recommendations list. 

# What?
Fixed the title

# Version Change
Patch
