### PR TITLE
Fix wrong Fiks Ferdig price label accessibility text.

### DIFF
--- a/Sources/Components/Fiks Ferdig/FiksFerdigPriceView/FiksFerdigPriceView.swift
+++ b/Sources/Components/Fiks Ferdig/FiksFerdigPriceView/FiksFerdigPriceView.swift
@@ -26,7 +26,6 @@ public final class FiksFerdigPriceView: UIView {
 
     private lazy var shippingLabel: Label = {
         let label = Label(style: .bodyStrong, withAutoLayout: true)
-        label.isAccessibilityElement = false
         label.numberOfLines = 0
         label.textColor = .textPrimary
         return label
@@ -91,7 +90,8 @@ public final class FiksFerdigPriceView: UIView {
         shippingLabel.isHidden = !hasPrice
 
         paymentLabel.attributedText = viewModel.payment.text
-        priceLabel.accessibilityLabel = viewModel.shippingAccessibilityLabel
+        priceLabel.accessibilityLabel = viewModel.priceString
+        shippingLabel.accessibilityLabel = viewModel.shipping.accessibilityText
         paymentLabel.accessibilityLabel = viewModel.payment.accessibilityText
     }
 

--- a/Sources/Components/Fiks Ferdig/FiksFerdigPriceView/FiksFerdigPriceViewModel.swift
+++ b/Sources/Components/Fiks Ferdig/FiksFerdigPriceView/FiksFerdigPriceViewModel.swift
@@ -25,10 +25,6 @@ public struct FiksFerdigPriceViewModel {
             return price
         }
     }
-
-    var shippingAccessibilityLabel: String {
-        return shipping.accessibilityText ?? shipping.text.string
-    }
 }
 
 extension FiksFerdigPriceViewModel {
@@ -40,7 +36,10 @@ extension FiksFerdigPriceViewModel {
     public struct Shipping {
         public let text: NSAttributedString
         public let darkModeText: NSAttributedString
-        public let accessibilityText: String?
+        private let providedAccessibilityText: String?
+        public var accessibilityText: String {
+            return providedAccessibilityText ?? text.string
+        }
 
         public init(
             text: NSAttributedString,
@@ -49,7 +48,7 @@ extension FiksFerdigPriceViewModel {
         ) {
             self.text = text
             self.darkModeText = darkModeText
-            self.accessibilityText = accessibilityText
+            self.providedAccessibilityText = accessibilityText
         }
     }
 


### PR DESCRIPTION
# Why?

The Fiks Ferdig price label had the wrong accessibility label for the price.

# What?

Set correct price and shipping accessibility labels.

# Version Change

Patch.
