### PR TITLE
Expect all future FinniversKit versions to also work

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(name: "FinniversKit", url: "https://github.com/finn-no/FinniversKit.git", from: "106.1.0")
+        .package(name: "FinniversKit", url: "https://github.com/finn-no/FinniversKit.git", "106.1.0"..."999.0.0")
     ],
     targets: [
     	.target(


### PR DESCRIPTION
# Why?
To avoid having to update a lot of repositories every time one of the base building blocks change major version.

# What?
Expect FinniversKit to not break anything used by FinnUI (and if it is something breaking that there will also be a change here).

# Version Change
Minor