### PR TITLE
TJT-2205 ShippingInfo providers

### DIFF
--- a/Sources/Components/Fiks Ferdig/FiksFerdigInfoView/FiksFerdigShippingInfoCell.swift
+++ b/Sources/Components/Fiks Ferdig/FiksFerdigInfoView/FiksFerdigShippingInfoCell.swift
@@ -16,7 +16,7 @@ public final class FiksFerdigShippingInfoCell: UIStackView {
         return label
     }()
 
-    private var providerIcon: UIImage {
+    private var providerIcon: UIImage? {
         switch viewModel.provider {
         case .heltHjem:
             return UIImage(named: .tjtHelthjemIcon)
@@ -24,6 +24,8 @@ public final class FiksFerdigShippingInfoCell: UIStackView {
             return UIImage(named: .tjtPostnordIcon)
         case .posten:
             return UIImage(named: .tjtPostenIcon)
+        default:
+            return nil
         }
     }
 

--- a/Sources/Components/Fiks Ferdig/FiksFerdigInfoView/FiksFerdigShippingInfoCellViewModel.swift
+++ b/Sources/Components/Fiks Ferdig/FiksFerdigInfoView/FiksFerdigShippingInfoCellViewModel.swift
@@ -1,8 +1,14 @@
 public class FiksFerdigShippingInfoCellViewModel {
-    public enum ShippingProvider {
-        case heltHjem
-        case postnord
-        case posten
+    public struct ShippingProvider: RawRepresentable, Hashable {
+        public let rawValue: String
+
+        public init(rawValue: String) {
+            self.rawValue = rawValue
+        }
+
+        public static var heltHjem: Self { Self(rawValue: "HELTHJEM") }
+        public static var posten: Self { Self(rawValue: "POSTEN") }
+        public static var postnord: Self { Self(rawValue: "POSTNORD") }
     }
 
     public let provider: ShippingProvider


### PR DESCRIPTION
# Why?

The shipping provider UI needs to work regardless of shipping provider ID.

# What?

Moved to struct for shipping provider ID so we can handle future shipping providers.

# Version Change

Minor, backwards compatible.
