### PR TITLE
Fix crash on duplicate recommendations in explore view

### DIFF
--- a/Sources/Extensions/Foundation/Array+Extensions.swift
+++ b/Sources/Extensions/Foundation/Array+Extensions.swift
@@ -15,3 +15,11 @@ extension Array {
         return indices.contains(index) ? self[index] : nil
     }
 }
+
+extension Array where Element: Hashable {
+    /// Return an array with any duplicates removed
+    func unique() -> [Element] {
+        var uniqueElements = Set(self)
+        return compactMap { uniqueElements.remove($0) }
+    }
+}

--- a/Sources/Fullscreen/Explore/ExploreView.swift
+++ b/Sources/Fullscreen/Explore/ExploreView.swift
@@ -200,9 +200,9 @@ public final class ExploreView: UIView {
             sections.append(section)
             snapshot.appendSections([section])
             recommendationsSection = viewModel.recommendationItems
-            let items = viewModel.recommendationItems.map {
-                Item.recommendation($0.self)
-            }
+            let items = viewModel.recommendationItems
+                .map { Item.recommendation($0.self) }
+                .unique()
             snapshot.appendItems(items, toSection: section)
         }
 


### PR DESCRIPTION
# Why?

There's a bug in the recommendations backend that causes duplicate recommendations. When this happens, the explore view (i.e. the reCommerce or jobs market front page) crashes with an `NSInternalInconsistencyException`. We should probably handle this, even if it's a bug on the backend side.

# What?

Filter out duplicate recommendation items before appending them to the explore view.

# Version Change

Patch