### PR TITLE
Fix crash on duplicate recommendations in loadMoreRecommendations

### DIFF
--- a/Sources/Fullscreen/Explore/ExploreView.swift
+++ b/Sources/Fullscreen/Explore/ExploreView.swift
@@ -235,7 +235,9 @@ public final class ExploreView: UIView {
         var snapshot = collectionViewDataSource.snapshot()
 
         recommendationsSection = recommendations
-        let items = recommendations.map(Item.recommendation)
+        let items = recommendations
+            .map(Item.recommendation)
+            .unique()
 
         snapshot.appendItems(items, toSection: .recommendations)
         collectionViewDataSource.apply(snapshot, animatingDifferences: false)


### PR DESCRIPTION
# Why?

I missed a spot in #127 

# What?

Filter out duplicate recommendation items in loadMoreRecommendations.

# Version Change

Patch