### PR TITLE
Remove unique filtering on recommendations in explore view

### DIFF
--- a/Sources/Fullscreen/Explore/ExploreView.swift
+++ b/Sources/Fullscreen/Explore/ExploreView.swift
@@ -202,7 +202,7 @@ public final class ExploreView: UIView {
             recommendationsSection = viewModel.recommendationItems
             let items = viewModel.recommendationItems
                 .map { Item.recommendation($0.self) }
-                .unique()
+
             snapshot.appendItems(items, toSection: section)
         }
 
@@ -237,7 +237,6 @@ public final class ExploreView: UIView {
         recommendationsSection = recommendations
         let items = recommendations
             .map(Item.recommendation)
-            .unique()
 
         snapshot.appendItems(items, toSection: .recommendations)
         collectionViewDataSource.apply(snapshot, animatingDifferences: false)

--- a/Sources/Fullscreen/Explore/ViewModels/ExploreRecommendationAdViewModel.swift
+++ b/Sources/Fullscreen/Explore/ViewModels/ExploreRecommendationAdViewModel.swift
@@ -1,6 +1,6 @@
 import FinniversKit
 
-final public class ExploreRecommendationAdViewModel: StandardAdRecommendationViewModel, Hashable {
+final public class ExploreRecommendationAdViewModel: UniqueHashableItem, StandardAdRecommendationViewModel {
     public let id: String
     public var imagePath: String?
     public var imageSize: CGSize
@@ -48,12 +48,5 @@ final public class ExploreRecommendationAdViewModel: StandardAdRecommendationVie
         self.favoriteButtonAccessibilityLabel = favoriteButtonAccessibilityLabel
         self.id = id
         self.badgeViewModel = badgeViewModel
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-    }
-    public static func == (lhs: ExploreRecommendationAdViewModel, rhs: ExploreRecommendationAdViewModel) -> Bool {
-        lhs.hashValue == rhs.hashValue
     }
 }

--- a/Sources/Fullscreen/Explore/ViewModels/ExploreRecommendationAdViewModel.swift
+++ b/Sources/Fullscreen/Explore/ViewModels/ExploreRecommendationAdViewModel.swift
@@ -1,6 +1,6 @@
 import FinniversKit
 
-final public class ExploreRecommendationAdViewModel: UniqueHashableItem, StandardAdRecommendationViewModel {
+final public class ExploreRecommendationAdViewModel: StandardAdRecommendationViewModel, Hashable {
     public let id: String
     public var imagePath: String?
     public var imageSize: CGSize
@@ -48,5 +48,12 @@ final public class ExploreRecommendationAdViewModel: UniqueHashableItem, Standar
         self.favoriteButtonAccessibilityLabel = favoriteButtonAccessibilityLabel
         self.id = id
         self.badgeViewModel = badgeViewModel
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+    public static func == (lhs: ExploreRecommendationAdViewModel, rhs: ExploreRecommendationAdViewModel) -> Bool {
+        lhs.hashValue == rhs.hashValue
     }
 }


### PR DESCRIPTION
# Why?

Filtering for unique caused an issue where certain ads weren't tappable because mismatching indeces. 

# What?

Hash ads based on a unique (per object) id instead of their ad id.

# Version Change

Patch